### PR TITLE
Fix typo in docstring

### DIFF
--- a/test/matpower.jl
+++ b/test/matpower.jl
@@ -397,7 +397,7 @@ end
 """
     _split_loads_shunts!(data)
 
-Seperates Loads and Shunts in `data` under separate "load" and "shunt" keys in the
+Separates Loads and Shunts in `data` under separate "load" and "shunt" keys in the
 PowerModels data format. Includes references to originating bus via "load_bus"
 and "shunt_bus" keys, respectively.
 """


### PR DESCRIPTION
## Summary
- correct a typo in the `_split_loads_shunts!` docstring

## Testing
- `julia -e 'using Pkg; Pkg.test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842094191f48328bd40ed0d29611f54